### PR TITLE
Refaktorierung der Logging-Funktionen

### DIFF
--- a/Logger.cs
+++ b/Logger.cs
@@ -335,31 +335,63 @@ namespace BigLog
                 PrefixCustom
                 ];
         }
-        // printing text
-        public void toTerm(string text)
+
+        /////////////////////
+        /// PRINTING-ZONE ///
+        /////////////////////
+
+        // text logging functions
+        public void Inf(string text)
         {
-            PrintToTerminal.ToTerm(this, text);
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, text, 0); }
+            if (LogToFile) { PrintToFile.ToFile(this, text, 0); }
+        }
+        public void Suc(string text)
+        {
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, text, 1); }
+            if (LogToFile) { PrintToFile.ToFile(this, text, 1); }
+        }
+        public void War(string text)
+        {
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, text, 2); }
+            if (LogToFile) { PrintToFile.ToFile(this, text, 2); }
+        }
+        public void Err(string text)
+        {
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, text, 3); }
+            if (LogToFile) { PrintToFile.ToFile(this, text, 3); }
+        }
+        public void Ctm(string text)
+        {
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, text, 4); }
+            if (LogToFile) { PrintToFile.ToFile(this, text, 4); }
         }
 
-        // printing exceptions
-        public void toTerm(Exception ex)
+        // exception logging functions
+        public void Inf(Exception ex)
         {
-            PrintToTerminal.ToTerm(this, ex.Message);
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, ex.Message, 0); }
+            if (LogToFile) { PrintToFile.ToFile(this, ex.Message, 0); }
         }
-
-        //////////////////////////
-        /// PRINTING-ZONE-FILE ///
-        //////////////////////////
-
-        // printing text
-        public void toFile(string text)
+        public void Suc(Exception ex)
         {
-            PrintToFile.ToFile(this, text);
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, ex.Message, 1); }
+            if (LogToFile) { PrintToFile.ToFile(this, ex.Message, 1); }
         }
-        // printing exceptions
-        public void toFile(Exception ex)
+        public void War(Exception ex)
         {
-            PrintToFile.ToFile(this, ex);
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, ex.Message, 2); }
+            if (LogToFile) { PrintToFile.ToFile(this, ex.Message, 2); }
+        }
+        public void Err(Exception ex)
+        {
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, ex.Message, 3); }
+            if (LogToFile) { PrintToFile.ToFile(this, ex.Message, 3); }
+        }
+        public void Ctm(Exception ex)
+        {
+            if (LogToTerminal) { PrintToTerminal.ToTerm(this, ex.Message, 4); }
+            if (LogToFile) { PrintToFile.ToFile(this, ex.Message, 4); }
         }
     }
 }

--- a/PrintToFile.cs
+++ b/PrintToFile.cs
@@ -10,13 +10,13 @@ namespace BigLog
     internal class PrintToFile
     {
         // level: 0 = inf, 1 = success, 2 = warning, 3 = error, 4 = custom
-        internal static void ToFile(Logger loggerImport, string text, int level = 0)
+        internal static void ToFile(Logger loggerImport, string text, int level)
         {
 
         }
-        internal static void ToFile(Logger loggerImport, Exception ex, int level = 0)
+        /*internal static void ToFile(Logger loggerImport, Exception ex, int level)
         {
 
-        }
+        }*/
     }
 }

--- a/PrintToTerminal.cs
+++ b/PrintToTerminal.cs
@@ -49,6 +49,6 @@ namespace BigLog
                 }
             }
         }
-        internal static void ToTerm(Logger loggerImport, Exception ex, int level) { ToTerm(loggerImport, ex.Message, level); }
+        //internal static void ToTerm(Logger loggerImport, Exception ex, int level) { ToTerm(loggerImport, ex.Message, level); }
     }
 }


### PR DESCRIPTION
Refaktorierung der Logging-Funktionen

Die Logging-Funktionen in `Logger.cs` wurden umstrukturiert, um spezifische Methoden für verschiedene Log-Level (`Inf`, `Suc`, `War`, `Err`, `Ctm`) einzuführen. Diese Methoden unterscheiden sich je nach Log-Level und ob sie für Text oder Ausnahmen verwendet werden. In `PrintToFile.cs` wurde die Methode `ToFile` für Ausnahmen auskommentiert und der Standardwert für den Level-Parameter entfernt. In `PrintToTerminal.cs` wurde die Methode `ToTerm` für Ausnahmen auskommentiert.